### PR TITLE
fix(style): make long description without space breaked by line

### DIFF
--- a/app/components/CircleCard.vue
+++ b/app/components/CircleCard.vue
@@ -355,6 +355,7 @@ export default {
     color: $black;
     font-size: 16px;
     line-height: 1.8;
+    word-break: break-all;
   }
 
   &__submit-btn {


### PR DESCRIPTION
**before**

<img width="1306" alt="스크린샷 2019-03-10 10 58 37" src="https://user-images.githubusercontent.com/16954420/54079634-7a858d80-4323-11e9-9232-0191b602b839.png">

**after**
<img width="1306" alt="스크린샷 2019-03-10 10 58 28" src="https://user-images.githubusercontent.com/16954420/54079635-7a858d80-4323-11e9-8784-bb3d2832e971.png">

This closes #135 