### PR TITLE
fix(style): DimiButtonGroup

### DIFF
--- a/app/dimiru/components/DimiButtonGroup.vue
+++ b/app/dimiru/components/DimiButtonGroup.vue
@@ -91,13 +91,6 @@ export default {
     border-top-right-radius: 4em;
   }
 
-  &__button:first-child::before,
-  &__button:last-child::after {
-    display: inline-block;
-    width: 2px;
-    content: '';
-  }
-
   &__button:not(:last-child) {
     border-right: 0;
   }


### PR DESCRIPTION
This closes #132 

**before**
<img width="127" alt="스크린샷 2019-03-19 08 56 30" src="https://user-images.githubusercontent.com/16954420/54571189-e8693d80-4a24-11e9-8308-cc9c476c9e11.png">

**after**
<img width="234" alt="스크린샷 2019-03-19 08 55 52" src="https://user-images.githubusercontent.com/16954420/54571162-d091b980-4a24-11e9-9f08-89abfc37323f.png">
