### PR TITLE
fix(mobile): mobile support for DimiButtonGroup

### DIFF
--- a/app/dimiru/components/DimiButtonGroup.vue
+++ b/app/dimiru/components/DimiButtonGroup.vue
@@ -56,18 +56,13 @@ export default {
   user-select: none;
 
   &__button {
-    display: table-cell;
+    display: inline-block;
     width: 205px;
     padding: 0.7em 2em;
     background-color: $red;
     cursor: pointer;
     text-align: center;
     transition: all 0.2s ease-in-out;
-    vertical-align: middle;
-
-    @include until($tablet) {
-      word-break: keep-all;
-    }
   }
 
   &__button:first-child {

--- a/app/dimiru/components/DimiButtonGroup.vue
+++ b/app/dimiru/components/DimiButtonGroup.vue
@@ -56,13 +56,18 @@ export default {
   user-select: none;
 
   &__button {
-    display: inline-block;
+    display: table-cell;
     width: 205px;
     padding: 0.7em 2em;
     background-color: $red;
     cursor: pointer;
     text-align: center;
     transition: all 0.2s ease-in-out;
+    vertical-align: middle;
+
+    @include until($tablet) {
+      word-break: keep-all;
+    }
   }
 
   &__button:first-child {


### PR DESCRIPTION
Closes #180 
커밋 메세지에서 디미루 컴포넌트 이름 `DimiButtonGroup`은 이전의 다른 커밋들처럼 대문자로 표기했습니다.

<img alt="localhost_8080_request_counsel(iPhone X)" src="https://user-images.githubusercontent.com/32605822/57976465-06025580-7a1c-11e9-825b-0bfcbc3c7243.png" width="70%">