### PR TITLE
feat(mobile): mobile support for mentoring manage

### DIFF
--- a/app/pages/paths/management/ManageMentoring.vue
+++ b/app/pages/paths/management/ManageMentoring.vue
@@ -701,11 +701,10 @@ export default {
   }
 
   &__cell--name {
-    width: 99%;
     color: $gray-dark;
 
-    @include until($tablet) {
-      width: unset;
+    @include from($tablet) {
+      width: 99%;
     }
   }
 

--- a/app/pages/paths/management/ManageMentoring.vue
+++ b/app/pages/paths/management/ManageMentoring.vue
@@ -214,6 +214,14 @@ export default {
       }
     },
 
+    async downloadExcel (grade) {
+      try {
+        await mentoringManager.downloadExcel(grade)
+      } catch (err) {
+        this.$swal('이런!', err.message, 'error')
+      }
+    },
+
     getDaySmallText (code) {
       return days.find(v => v.code === code).smallText
     }
@@ -273,6 +281,13 @@ export default {
             @click="deleteChecked"
           >
             <span class="mng-mentoring__delete-icon icon-delete" /> 선택 삭제
+          </span>
+
+          <span
+            class="mng-mentoring__tool mng-mentoring__excel"
+            @click="downloadExcel(tab + 1)"
+          >
+            <span class="mng-afsc__excel-icon icon-long-arrow-down" /> 엑셀 다운로드
           </span>
 
           <dimi-dropdown
@@ -625,15 +640,12 @@ export default {
     user-select: none;
   }
 
-  &__delete {
+  &__delete,
+  &__excel {
     display: flex;
     align-items: center;
     cursor: pointer;
     user-select: none;
-  }
-
-  &__sort {
-    margin-left: 1em !important;
   }
 
   &__delete-icon {

--- a/app/pages/paths/management/ManageMentoring.vue
+++ b/app/pages/paths/management/ManageMentoring.vue
@@ -646,10 +646,24 @@ export default {
     color: $gray-light;
     font-size: 16px;
     font-weight: $font-weight-bold;
+    @include until($tablet) {
+      flex-wrap: wrap;
+      justify-content: space-between;
+    }
   }
-
+  
   &__tool:not(:first-child) {
     margin-left: 2em;
+  }
+
+  &__tool {
+    @include until($tablet) {
+      display: inline-block;
+      width: 40%;
+      justify-content: flex-start;
+      margin-left: unset !important;
+      text-align: left;
+    }
   }
 
   &__select-all {
@@ -682,14 +696,17 @@ export default {
 
   &__cell {
     padding: 24px 0;
-    color: $gray-dark;
+    color: $gray;
     white-space: nowrap;
   }
 
   &__cell--name {
     width: 99%;
-    color: $black;
-    white-space: normal;
+    color: $gray-dark;
+
+    @include until($tablet) {
+      width: unset;
+    }
   }
 
   &__cell:not(:last-child):not(:nth-last-child(2)) {

--- a/app/pages/paths/management/ManageMentoring.vue
+++ b/app/pages/paths/management/ManageMentoring.vue
@@ -651,7 +651,7 @@ export default {
       justify-content: space-between;
     }
   }
-  
+
   &__tool:not(:first-child) {
     margin-left: 2em;
   }

--- a/app/pages/paths/management/ManageMentoring.vue
+++ b/app/pages/paths/management/ManageMentoring.vue
@@ -232,7 +232,9 @@ export default {
 <template>
   <content-wrapper class="mng-mentoring">
     <h1 slot="header">
-      <span class="icon-comment" />멘토링 신청 관리
+      <span class="mng-mentoring__head">
+        <span class="icon-comment" />멘토링 신청 관리
+      </span>
       <span
         class="mng-mentoring__create"
         @click="modal.create = true"
@@ -585,6 +587,14 @@ export default {
   }
 }
 
+.content {
+  @include until($tablet) {
+    &__header > h1 {
+      margin-bottom: 1.8em;
+    }
+  }
+}
+
 .mng-mentoring {
   &__main {
     padding: 0;
@@ -597,6 +607,12 @@ export default {
 
   &__section:last-child {
     padding-bottom: 0;
+  }
+
+  &__head {
+    @include until($tablet) {
+      display: block;
+    }
   }
 
   &__notice {

--- a/app/src/api/mentoring/mentoring.service.js
+++ b/app/src/api/mentoring/mentoring.service.js
@@ -123,4 +123,22 @@ export class MentoringManagerService extends MentoringService {
     })
     return mentors.map(Mentoring)
   }
+
+  /**
+   * 학년별 멘토링 엑셀 파일을 다운로드합니다.
+   */
+  async downloadExcel (grade) {
+    const { data } = await this.magician(() => this.r.get(`/excel/${grade}`, {
+      responseType: 'blob'
+    }), {
+      403: '권한이 없습니다.',
+      default: '파일을 다운로드하던 중 문제가 발생했습니다.'
+    })
+    const link = document.createElement('a')
+    link.href = window.URL.createObjectURL(new Blob([data]))
+    link.setAttribute('download', `${new Date().getFullYear()}년도 ${grade}학년 멘토링 신청 목록.xlsx`)
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+  }
 }


### PR DESCRIPTION
Closes #230 

<img alt="localhost_8080_management_mentoring(Galaxy S5)" src="https://user-images.githubusercontent.com/32605822/57976834-d1df6280-7a24-11e9-9ae6-89ab04d0e75d.png" width="70%">

- 모바일 디바이스에서 상단 헤더에 있는 **공지사항 관리**, **추가하기** 버튼 위치를 조정했습니다.
- `toolbar`와 `cell--name`을 수정하여 컨텐츠가 깨지지 않으면서도 horizontal scroll이 가능하게 했습니다.